### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   },
   "author": "will123195",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/will123195/p2p-broadcast.git"
+  },
   "devDependencies": {
     "bluebird": "^3.5.0",
     "tape": "^4.8.0"


### PR DESCRIPTION
Makes it easier to find the associated repository, when accessing this package from npm.